### PR TITLE
US-02: Cargo.toml with std/no_std features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,13 @@
 name = "lemi"
 version = "0.1.0"
 edition = "2021"
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+libm = { version = "0.2", default-features = false }
+
+[dev-dependencies]
+serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-// placeholder — expanded in US-02
+#![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
## Summary

- Replaces Cargo.toml stub with full std/no_std feature configuration
- Adds libm 0.2 (no_std-compatible transcendental math)
- Adds serde_json dev-dependency for fixture loading in later sprints
- Adds no_std cfg_attr gate to src/lib.rs

## Traceability

US-02 → RNF-P1

## Test plan

- [ ] `cargo build` passes with zero warnings
- [ ] `cargo build --no-default-features` passes with zero warnings