### PR TITLE
US-04: Full CI pipeline (lake + cargo + Cortex-M4 + Python)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,27 @@ jobs:
       - name: Lake build
         run: lake build
 
-  cargo-build:
+  cargo-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build
+      - run: cargo test
+
+  cortex-m4:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7em-none-eabihf
+      - run: cargo build --target thumbv7em-none-eabihf --no-default-features
+
+  python-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: python eval/rbj_reference.py


### PR DESCRIPTION
## Summary

- Expands CI from 2 jobs to 4: lake-build, cargo-test, cortex-m4, python-fixtures
- Cortex-M4 job cross-compiles with thumbv7em-none-eabihf and --no-default-features
- Python job runs eval/rbj_reference.py as a stub sanity check

## Traceability

US-04 → RNF-M1

## Test plan

- [ ] All four CI jobs pass on this PR