### PR TITLE
US-05: ValidParams structure in FilterParams.lean

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,3 +5,7 @@ package "lemi" where
   version := v!"0.1.0"
 
 require "leanprover-community" / "mathlib" @ git "master"
+
+lean_lib «Lemi» where
+  srcDir := "lean"
+  roots := #[`FilterParams]

--- a/lean/FilterParams.lean
+++ b/lean/FilterParams.lean
@@ -1,0 +1,24 @@
+import Mathlib
+
+/-!
+# Filter Parameters
+
+Defines `ValidParams` — the validated parameter record that serves as the
+sole hypothesis of all filter stability theorems in this library.
+-/
+
+/-- Validated parameters for a parametric biquad filter. All constraints
+    are embedded as field hypotheses, making any `ValidParams` structurally
+    correct by construction. -/
+structure ValidParams where
+  f0   : ℝ  -- centre frequency (Hz)
+  fs   : ℝ  -- sample rate (Hz)
+  q    : ℝ  -- quality factor
+  gain : ℝ  -- shelf/peaking gain (dB), may be negative
+  s    : ℝ  -- shelf slope in (0, 1]
+  hf0      : 0 < f0
+  hfs      : 0 < fs
+  hNyquist : f0 < fs / 2
+  hq       : 0 < q
+  hs       : 0 < s
+  hs1      : s ≤ 1


### PR DESCRIPTION
## Summary

- Creates lean/FilterParams.lean with the ValidParams structure
- Six embedded hypothesis fields (hf0, hfs, hNyquist, hq, hs, hs1)
- Updates lakefile.lean to declare lean_lib «Lemi» with FilterParams root
- Compiles via lake build with no errors

## Traceability

US-05 → RF-L1

## Test plan

- [ ] `lake build` passes with no errors