### PR TITLE
US-06: FilterType inductive with three constructors

### DIFF
--- a/lean/FilterParams.lean
+++ b/lean/FilterParams.lean
@@ -22,3 +22,10 @@ structure ValidParams where
   hq       : 0 < q
   hs       : 0 < s
   hs1      : s ≤ 1
+
+/-- Filter topology used in RBJ parametric biquad formulas. -/
+inductive FilterType
+  | Peaking   : FilterType
+  | LowShelf  : FilterType
+  | HighShelf : FilterType
+  deriving Repr, DecidableEq


### PR DESCRIPTION
## Summary

- Appends FilterType inductive to lean/FilterParams.lean
- Three constructors: Peaking, LowShelf, HighShelf
- Derives Repr and DecidableEq

## Traceability

US-06 → RF-L1

## Test plan

- [ ] `lake build` passes with no errors
- [ ] `#check FilterType` returns no error