### PR TITLE
US-07: omega() and A() noncomputable definitions

### DIFF
--- a/lean/FilterParams.lean
+++ b/lean/FilterParams.lean
@@ -29,3 +29,11 @@ inductive FilterType
   | LowShelf  : FilterType
   | HighShelf : FilterType
   deriving Repr, DecidableEq
+
+/-- Angular centre frequency in radians per sample: ω₀ = 2π · f₀ / fₛ -/
+noncomputable def ValidParams.omega (p : ValidParams) : ℝ :=
+  2 * Real.pi * p.f0 / p.fs
+
+/-- Gain amplitude factor: A = √(10^(gain/20)) -/
+noncomputable def ValidParams.A (p : ValidParams) : ℝ :=
+  Real.sqrt (10 ^ (p.gain / 20))


### PR DESCRIPTION
## Summary

- Adds ValidParams.omega: ω₀ = 2π·f₀/fₛ (angular centre frequency)
- Adds ValidParams.A: A = √(10^(gain/20)) (gain amplitude factor)
- Both are noncomputable, referenced by stability theorems in sprints 5–6

## Traceability

US-07 → RF-L1

## Test plan

- [ ] `lake build` passes with no errors
- [ ] `#check ValidParams.omega` produces no error
- [ ] `#check ValidParams.A` produces no error