### PR TITLE
US-08: BilinearTransform.lean compilable prototype (sorry)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -8,4 +8,4 @@ require "leanprover-community" / "mathlib" @ git "master"
 
 lean_lib «Lemi» where
   srcDir := "lean"
-  roots := #[`FilterParams]
+  roots := #[`FilterParams, `BilinearTransform]

--- a/lean/BilinearTransform.lean
+++ b/lean/BilinearTransform.lean
@@ -1,0 +1,20 @@
+import Mathlib
+
+/-!
+# Bilinear Transform
+
+Formal statement that the standard bilinear transform maps the open unit
+disk to the open left half-plane. The real proof is deferred to Sprint 5
+(US-09); `sorry` is used as a placeholder, permitted in sprints S1–S3.
+-/
+
+open Complex
+
+/-- The bilinear transform: s = (z − 1) / (z + 1). -/
+noncomputable def bilinearMap (z : ℂ) : ℂ := (z - 1) / (z + 1)
+
+/-- Every z with |z| < 1 maps to a point with strictly negative real part
+    (the open left half-plane). -/
+theorem bilinear_maps_disk_to_lhp (z : ℂ) (hz : Complex.abs z < 1) :
+    (bilinearMap z).re < 0 := by
+  sorry


### PR DESCRIPTION
## Summary

- Creates lean/BilinearTransform.lean with bilinearMap definition
- States bilinear_maps_disk_to_lhp theorem (|z| < 1 → Re(s) < 0)
- Compiles with sorry per DoD allowance for prototype sprints S1–S3
- Real proof scheduled for Sprint 5 (US-09)
- Updates lakefile.lean lean_lib roots to include BilinearTransform

## Traceability

US-08 → RF-L2

## Test plan

- [ ] `lake build` compiles with no errors (sorry axiom warning is acceptable)