### PR TITLE
US-31: rbj_reference.py low_shelf and high_shelf

### DIFF
--- a/eval/rbj_reference.py
+++ b/eval/rbj_reference.py
@@ -13,12 +13,16 @@ biquad filter coefficients."
 import math
 
 
-def _intermediates(f0: float, fs: float, q: float, gain: float) -> tuple[float, float, float, float]:
+def _intermediates(f0: float, fs: float, gain: float) -> tuple[float, float, float, float]:
     """Returns (omega, sin_omega, cos_omega, A).
 
-    These four values appear in every RBJ formula. Computing them once
-    and re-using guarantees the same intermediate floating-point values
-    are seen by every coefficient expression.
+    Shared by peaking, low_shelf, and high_shelf — the four values
+    appear in every RBJ formula. Computing them once and re-using
+    guarantees the same intermediate floating-point values are seen
+    by every coefficient expression.
+
+    NOTE: math.pow is used (not **) to mirror libm::pow on the Rust
+    side. Do not "simplify" this.
     """
     omega = 2.0 * math.pi * f0 / fs
     sin_omega = math.sin(omega)
@@ -32,7 +36,7 @@ def peaking(f0: float, fs: float, q: float, gain: float) -> dict[str, float]:
 
     Returns a dict with keys b0, b1, b2, a1, a2 — already normalized by a0.
     """
-    _omega, sin_omega, cos_omega, a = _intermediates(f0, fs, q, gain)
+    _omega, sin_omega, cos_omega, a = _intermediates(f0, fs, gain)
     alpha = sin_omega / (2.0 * q)
 
     a0 = 1.0 + alpha / a
@@ -45,6 +49,53 @@ def peaking(f0: float, fs: float, q: float, gain: float) -> dict[str, float]:
     return {"b0": b0, "b1": b1, "b2": b2, "a1": a1, "a2": a2}
 
 
+def low_shelf(f0: float, fs: float, s: float, gain: float) -> dict[str, float]:
+    """Low Shelf filter coefficients per RBJ Cookbook §3.6.
+
+    Uses shelf slope `s` instead of quality factor Q. Returns a dict
+    with keys b0, b1, b2, a1, a2 — already normalized by a0.
+    """
+    _omega, sin_omega, cos_omega, a = _intermediates(f0, fs, gain)
+    # Shelf alpha differs from peaking alpha; it uses s, not Q.
+    alpha = (sin_omega / 2.0) * math.sqrt((a + 1.0 / a) * (1.0 / s - 1.0) + 2.0)
+    sqrt_a = math.sqrt(a)
+    two_sqrt_a_alpha = 2.0 * sqrt_a * alpha
+
+    a0 = (a + 1.0) + (a - 1.0) * cos_omega + two_sqrt_a_alpha
+    b0 = (a * ((a + 1.0) - (a - 1.0) * cos_omega + two_sqrt_a_alpha)) / a0
+    b1 = (2.0 * a * ((a - 1.0) - (a + 1.0) * cos_omega)) / a0
+    b2 = (a * ((a + 1.0) - (a - 1.0) * cos_omega - two_sqrt_a_alpha)) / a0
+    a1 = (-2.0 * ((a - 1.0) + (a + 1.0) * cos_omega)) / a0
+    a2 = ((a + 1.0) + (a - 1.0) * cos_omega - two_sqrt_a_alpha) / a0
+
+    return {"b0": b0, "b1": b1, "b2": b2, "a1": a1, "a2": a2}
+
+
+def high_shelf(f0: float, fs: float, s: float, gain: float) -> dict[str, float]:
+    """High Shelf filter coefficients per RBJ Cookbook §3.7.
+
+    Uses shelf slope `s` instead of quality factor Q. Returns a dict
+    with keys b0, b1, b2, a1, a2 — already normalized by a0.
+    """
+    _omega, sin_omega, cos_omega, a = _intermediates(f0, fs, gain)
+    alpha = (sin_omega / 2.0) * math.sqrt((a + 1.0 / a) * (1.0 / s - 1.0) + 2.0)
+    sqrt_a = math.sqrt(a)
+    two_sqrt_a_alpha = 2.0 * sqrt_a * alpha
+
+    a0 = (a + 1.0) - (a - 1.0) * cos_omega + two_sqrt_a_alpha
+    b0 = (a * ((a + 1.0) + (a - 1.0) * cos_omega + two_sqrt_a_alpha)) / a0
+    b1 = (-2.0 * a * ((a - 1.0) + (a + 1.0) * cos_omega)) / a0
+    b2 = (a * ((a + 1.0) + (a - 1.0) * cos_omega - two_sqrt_a_alpha)) / a0
+    a1 = (2.0 * ((a - 1.0) - (a + 1.0) * cos_omega)) / a0
+    a2 = ((a + 1.0) - (a - 1.0) * cos_omega - two_sqrt_a_alpha) / a0
+
+    return {"b0": b0, "b1": b1, "b2": b2, "a1": a1, "a2": a2}
+
+
 if __name__ == "__main__":
-    nominal = peaking(1000.0, 44100.0, 1.0, 6.0)
-    print(f"peaking(1000, 44100, 1.0, 6.0) = {nominal}")
+    nominal_p = peaking(1000.0, 44100.0, 1.0, 6.0)
+    nominal_ls = low_shelf(1000.0, 44100.0, 1.0, 6.0)
+    nominal_hs = high_shelf(1000.0, 44100.0, 1.0, 6.0)
+    print(f"peaking    = {nominal_p}")
+    print(f"low_shelf  = {nominal_ls}")
+    print(f"high_shelf = {nominal_hs}")


### PR DESCRIPTION
## Summary

- Adds low_shelf and high_shelf to eval/rbj_reference.py
- Both use shelf slope s instead of Q (per RBJ Cookbook §3.6, §3.7)
- Refactors _intermediates to drop unused q parameter
- Same canonical evaluation order Rust will match in US-23 and US-24

## Traceability

US-31 → RF-E1

## Test plan

- [ ] python eval/rbj_reference.py runs without exception
- [ ] Unity gain produces identity for both shelf types