### PR TITLE
US-33: ulp_distance with NaN guard and signed-zero normalization

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,30 @@
+//! Test-only numerical helpers shared across integration tests.
+//!
+//! Cargo treats `tests/common/mod.rs` as a non-test submodule (the file is
+//! `mod.rs` inside a subdirectory). It is included via `mod common;` from
+//! each integration test file.
+
+#![allow(dead_code)]
+
+/// Distance between two `f64` values in units in the last place (ULPs).
+///
+/// Panics if either argument is NaN — `assert_coeffs_within_ulp` and the
+/// like rely on this contract so that a silent NaN propagation does not
+/// pass an ULP comparison.
+///
+/// `+0.0` and `-0.0` are normalized to the same bit pattern before
+/// comparison, so `ulp_distance(0.0, -0.0)` returns 0.
+pub fn ulp_distance(a: f64, b: f64) -> u64 {
+    if a.is_nan() || b.is_nan() {
+        panic!("ulp_distance: NaN input (a = {}, b = {})", a, b);
+    }
+    let normalize = |x: f64| if x == 0.0 { 0.0 } else { x };
+    let a = normalize(a);
+    let b = normalize(b);
+    let ai = a.to_bits() as i64;
+    let bi = b.to_bits() as i64;
+    // Convert from biased two's-complement representation so adjacent
+    // finite f64 values differ by exactly 1.
+    let to_lex = |x: i64| if x >= 0 { x } else { i64::MIN - x };
+    (to_lex(ai) - to_lex(bi)).unsigned_abs()
+}

--- a/tests/common_smoke.rs
+++ b/tests/common_smoke.rs
@@ -1,0 +1,24 @@
+mod common;
+
+#[test]
+fn smoke_zero_distance() {
+    assert_eq!(common::ulp_distance(1.0, 1.0), 0);
+}
+
+#[test]
+fn smoke_one_ulp() {
+    let a = 1.0_f64;
+    let b = f64::from_bits(a.to_bits() + 1);
+    assert_eq!(common::ulp_distance(a, b), 1);
+}
+
+#[test]
+fn smoke_signed_zero() {
+    assert_eq!(common::ulp_distance(0.0, -0.0), 0);
+}
+
+#[test]
+#[should_panic(expected = "NaN input")]
+fn smoke_nan_panics() {
+    let _ = common::ulp_distance(f64::NAN, 1.0);
+}


### PR DESCRIPTION
## Summary

- Adds tests/common/mod.rs with ulp_distance(a, b) helper
- Returns 0 for ±0.0 (signed-zero normalization)
- Panics on NaN input (contract enforced by smoke test)
- tests/common_smoke.rs covers four contract cases

## Traceability

US-33 → RNF-N3

## Test plan

- [ ] cargo test --test common_smoke passes (4 tests)