### PR TITLE
US-34: assert_coeffs_within_ulp helper

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,3 +28,35 @@ pub fn ulp_distance(a: f64, b: f64) -> u64 {
     let to_lex = |x: i64| if x >= 0 { x } else { i64::MIN - x };
     (to_lex(ai) - to_lex(bi)).unsigned_abs()
 }
+
+/// Asserts that two `BiquadCoeffs`-shaped values agree on all five
+/// coefficients within `tol` ULPs.
+///
+/// Takes the five coefficients of each side as `f64` tuples so the helper
+/// is decoupled from the concrete `BiquadCoeffs` type — integration tests
+/// pass `(c.b0, c.b1, c.b2, c.a1, c.a2)` for each side. This avoids the
+/// complication of trying to share a `#[macro_export]` macro between the
+/// `src/` crate and the `tests/` integration test set.
+///
+/// On failure, the panic message includes the label, the offending
+/// coefficient name, both values, and the actual ULP distance.
+pub fn assert_coeffs_within_ulp(
+    label: &str,
+    got: (f64, f64, f64, f64, f64),
+    expected: (f64, f64, f64, f64, f64),
+    tol: u64,
+) {
+    let names = ["b0", "b1", "b2", "a1", "a2"];
+    let got_arr = [got.0, got.1, got.2, got.3, got.4];
+    let expected_arr = [expected.0, expected.1, expected.2, expected.3, expected.4];
+    for (i, name) in names.iter().enumerate() {
+        let g = got_arr[i];
+        let e = expected_arr[i];
+        let dist = ulp_distance(g, e);
+        assert!(
+            dist <= tol,
+            "[{}] {} exceeded {} ULP: got = {:.17e}, expected = {:.17e}, distance = {} ULP",
+            label, name, tol, g, e, dist
+        );
+    }
+}

--- a/tests/common_smoke.rs
+++ b/tests/common_smoke.rs
@@ -22,3 +22,19 @@ fn smoke_signed_zero() {
 fn smoke_nan_panics() {
     let _ = common::ulp_distance(f64::NAN, 1.0);
 }
+
+#[test]
+fn assert_coeffs_within_ulp_passes_for_equal() {
+    let a = (1.0, 2.0, 3.0, 4.0, 5.0);
+    let b = (1.0, 2.0, 3.0, 4.0, 5.0);
+    common::assert_coeffs_within_ulp("smoke", a, b, 0);
+}
+
+#[test]
+#[should_panic(expected = "exceeded 0 ULP")]
+fn assert_coeffs_within_ulp_panics_for_one_ulp_off() {
+    let a: (f64, f64, f64, f64, f64) = (1.0, 2.0, 3.0, 4.0, 5.0);
+    let b0_off = f64::from_bits(a.0.to_bits() + 1);
+    let b = (b0_off, 2.0, 3.0, 4.0, 5.0);
+    common::assert_coeffs_within_ulp("smoke", a, b, 0);
+}


### PR DESCRIPTION
## Summary

- Appends assert_coeffs_within_ulp helper to tests/common/mod.rs
- Verifies all five coefficients with informative failure messages
- Decoupled from BiquadCoeffs type by taking f64 tuples
- Two smoke tests: equal passes, 1-ULP difference panics

## Traceability

US-34 -> RNF-C3

## Test plan

- [ ] cargo test --test common_smoke passes (6 tests)