### PR TITLE
US-35: peaking_nominal_44100 ULP test against JSON fixture

### DIFF
--- a/tests/coefficients.rs
+++ b/tests/coefficients.rs
@@ -48,3 +48,40 @@ fn unity_gain_is_identity_high_shelf() {
         4,
     );
 }
+
+/// Loads the committed JSON fixture and verifies the Rust `peaking`
+/// implementation agrees with the Python reference to <= 4 ULP for the
+/// nominal record (f0=1000, fs=44100, Q=1, gain=6).
+#[test]
+fn peaking_nominal_44100() {
+    use serde_json::Value;
+
+    let fixture_text = include_str!("../fixtures/rbj_coefficients.json");
+    let records: Vec<Value> =
+        serde_json::from_str(fixture_text).expect("fixture must parse");
+
+    let record = records
+        .iter()
+        .find(|r| {
+            r["type"] == "peaking"
+                && r["f0"].as_f64() == Some(1000.0)
+                && r["fs"].as_f64() == Some(44100.0)
+                && r["q"].as_f64() == Some(1.0)
+                && r["gain"].as_f64() == Some(6.0)
+        })
+        .expect("nominal peaking record not present in fixture");
+
+    let params = ValidParams::new(1000.0, 44100.0, 1.0, 6.0, 1.0).unwrap();
+    let computed = BiquadCoeffs::peaking(&params);
+
+    let expected = (
+        record["b0"].as_f64().unwrap(),
+        record["b1"].as_f64().unwrap(),
+        record["b2"].as_f64().unwrap(),
+        record["a1"].as_f64().unwrap(),
+        record["a2"].as_f64().unwrap(),
+    );
+    let got = (computed.b0, computed.b1, computed.b2, computed.a1, computed.a2);
+
+    common::assert_coeffs_within_ulp("peaking@1k/44.1k/Q1/+6dB", got, expected, 4);
+}


### PR DESCRIPTION
## Summary

- Adds peaking_nominal_44100 to tests/coefficients.rs
- Loads fixtures/rbj_coefficients.json via include_str!
- Verifies Rust peaking matches Python reference to <= 4 ULP

## Traceability

US-35 -> RF-E2

## Test plan

- [ ] cargo test --test coefficients passes (4 tests)